### PR TITLE
Add support for choosing videos

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.3.31'
+    ext.kotlin_version = '1.3.61'
     repositories {
         google()
         jcenter()

--- a/photopicker/build.gradle
+++ b/photopicker/build.gradle
@@ -43,10 +43,10 @@ dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 
-    implementation "androidx.core:core-ktx:1.2.0-beta01"
+    implementation 'androidx.core:core-ktx:1.3.0-alpha02'
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation "com.google.android.material:material:1.1.0-beta01"
+    implementation 'com.google.android.material:material:1.2.0-alpha05'
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.2"
-    implementation "androidx.lifecycle:lifecycle-extensions:2.1.0"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
 }

--- a/photopicker/src/main/AndroidManifest.xml
+++ b/photopicker/src/main/AndroidManifest.xml
@@ -3,7 +3,7 @@
 
     <uses-permission android:name="android.permission.CAMERA" />
 
-    <application>
+    <application android:requestLegacyExternalStorage="true">
 
         <activity
             android:name=".utils.CameraActivity"

--- a/photopicker/src/main/java/lv/chi/photopicker/PickerViewModel.kt
+++ b/photopicker/src/main/java/lv/chi/photopicker/PickerViewModel.kt
@@ -10,16 +10,16 @@ import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import lv.chi.photopicker.adapter.SelectableImage
+import lv.chi.photopicker.adapter.SelectableMedia
 import lv.chi.photopicker.utils.SingleLiveEvent
 
 internal class PickerViewModel : ViewModel() {
 
-    private val hasContentData = MutableLiveData<Boolean>(false)
-    private val inProgressData = MutableLiveData<Boolean>(false)
-    private val hasPermissionData = MutableLiveData<Boolean>(false)
+    private val hasContentData = MutableLiveData(false)
+    private val inProgressData = MutableLiveData(false)
+    private val hasPermissionData = MutableLiveData(false)
     private val selectedData = MutableLiveData<ArrayList<Uri>>(arrayListOf())
-    private val photosData = MutableLiveData<ArrayList<SelectableImage>>(arrayListOf())
+    private val mediaData = MutableLiveData<ArrayList<SelectableMedia>>(arrayListOf())
     private val maxSelectionReachedData = SingleLiveEvent<Unit>()
 
     private var maxSelectionCount = SELECTION_UNDEFINED
@@ -28,7 +28,7 @@ internal class PickerViewModel : ViewModel() {
     val inProgress: LiveData<Boolean> = inProgressData
     val hasPermission: LiveData<Boolean> = hasPermissionData
     val selected: LiveData<ArrayList<Uri>> = selectedData
-    val photos: LiveData<ArrayList<SelectableImage>> = photosData
+    val mediaItems: LiveData<ArrayList<SelectableMedia>> = mediaData
     val maxSelectionReached: LiveData<Unit> = maxSelectionReachedData
 
     fun setHasPermission(hasPermission: Boolean) = hasPermissionData.postValue(hasPermission)
@@ -39,24 +39,24 @@ internal class PickerViewModel : ViewModel() {
 
     fun clearSelected() {
         GlobalScope.launch {
-            val photos = requireNotNull(photosData.value).map { it.copy(selected = false) }
-            val array = arrayListOf<SelectableImage>()
-            array.addAll(photos)
-            photosData.postValue(array)
+            val mediaItems = requireNotNull(mediaData.value).map { it.copy(selected = false) }
+            val array = arrayListOf<SelectableMedia>()
+            array.addAll(mediaItems)
+            mediaData.postValue(array)
             selectedData.postValue(arrayListOf())
         }
     }
 
-    fun setPhotos(cursor: Cursor?) {
+    fun setMedia(cursor: Cursor?) {
         cursor?.let { c ->
-            val array = arrayListOf<SelectableImage>()
+            val array = arrayListOf<SelectableMedia>()
             array.addAll(
                 generateSequence { if (c.moveToNext()) c else null }
                     .map { readValueAtCursor(cursor) }
                     .toList()
             )
             hasContentData.postValue(array.isNotEmpty())
-            photosData.postValue(array)
+            mediaData.postValue(array)
         }
     }
 
@@ -64,35 +64,36 @@ internal class PickerViewModel : ViewModel() {
         inProgressData.postValue(progress)
     }
 
-    fun toggleSelected(photo: SelectableImage) {
+    fun toggleSelected(media: SelectableMedia) {
         GlobalScope.launch(Dispatchers.IO) {
             val selected = requireNotNull(selectedData.value)
 
             when {
-                photo.selected -> selected.remove(photo.uri)
-                canSelectMore(selected.size) -> selected.add(photo.uri)
+                media.selected -> selected.remove(media.uri)
+                canSelectMore(selected.size) -> selected.add(media.uri)
                 else -> {
                     maxSelectionReachedData.postValue(Unit)
                     return@launch
                 }
             }
 
-            val photos = requireNotNull(photosData.value)
-            photos.indexOfFirst { item -> item.id == photo.id }
+            val mediaItems = requireNotNull(mediaData.value)
+            mediaItems.indexOfFirst { item -> item.id == media.id }
                 .takeIf { pos -> pos != -1 }
-                ?.let { pos -> photos[pos] = photo.copy(selected = !photo.selected) }
+                ?.let { pos -> mediaItems[pos] = media.copy(selected = !media.selected) }
 
             selectedData.postValue(selected)
-            photosData.postValue(photos)
+            mediaData.postValue(mediaItems)
+
         }
     }
 
     private fun canSelectMore(size: Int) = maxSelectionCount == SELECTION_UNDEFINED || maxSelectionCount > size
 
-    private fun readValueAtCursor(cursor: Cursor): SelectableImage {
+    private fun readValueAtCursor(cursor: Cursor): SelectableMedia {
         val id = cursor.getInt(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns._ID))
         val uri = "file://${cursor.getString(cursor.getColumnIndexOrThrow(MediaStore.MediaColumns.DATA))}"
-        return SelectableImage(id, Uri.parse(uri), false)
+        return SelectableMedia(id, Uri.parse(uri), false)
     }
 
     companion object {

--- a/photopicker/src/main/java/lv/chi/photopicker/adapter/MediaPickerAdapter.kt
+++ b/photopicker/src/main/java/lv/chi/photopicker/adapter/MediaPickerAdapter.kt
@@ -6,26 +6,26 @@ import android.view.ViewGroup
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import kotlinx.android.synthetic.main.view_pickable_image.view.*
+import kotlinx.android.synthetic.main.view_pickable_media_item.view.*
 import lv.chi.photopicker.R
 import lv.chi.photopicker.loader.ImageLoader
 
-internal class ImagePickerAdapter(
-    private val onImageClick: (SelectableImage) -> Unit,
+internal class MediaPickerAdapter(
+    private val onMediaItemClicked: (SelectableMedia) -> Unit,
     private val multiple: Boolean,
     private val imageLoader: ImageLoader
-) : ListAdapter<SelectableImage, ImagePickerAdapter.ImagePickerViewHolder>(DiffCallback) {
+) : ListAdapter<SelectableMedia, MediaPickerAdapter.VideoPickerViewHolder>(DiffCallback) {
 
     override fun onCreateViewHolder(parent: ViewGroup, type: Int) =
-        ImagePickerViewHolder(
+        VideoPickerViewHolder(
             LayoutInflater
                 .from(parent.context)
-                .inflate(R.layout.view_pickable_image, parent, false)
+                .inflate(R.layout.view_pickable_media_item, parent, false)
                 .apply { checkbox.visibility = if (multiple) View.VISIBLE else View.GONE }
         )
 
     override fun onBindViewHolder(
-        holder: ImagePickerViewHolder,
+        holder: VideoPickerViewHolder,
         position: Int,
         payloads: MutableList<Any>
     ) {
@@ -34,34 +34,34 @@ internal class ImagePickerAdapter(
         } ?: super.onBindViewHolder(holder, position, payloads)
     }
 
-    override fun onBindViewHolder(holder: ImagePickerViewHolder, position: Int) {
+    override fun onBindViewHolder(holder: VideoPickerViewHolder, position: Int) {
         val item = getItem(position)
         holder.view.apply {
-            imageLoader.loadImage(context, photo_item, item.uri)
-            setOnClickListener { onImageClick(getItem(position)) }
+            imageLoader.loadImage(context, media_item, item.uri)
+            setOnClickListener { onMediaItemClicked(getItem(position)) }
             checkbox.isChecked = item.selected
         }
     }
 
-    class ImagePickerViewHolder(val view: View) : RecyclerView.ViewHolder(view)
+    inner class VideoPickerViewHolder(val view: View) : RecyclerView.ViewHolder(view)
 
     companion object {
         private const val SELECTED_PAYLOAD = "selected_payload"
 
-        private val DiffCallback = object : DiffUtil.ItemCallback<SelectableImage>() {
+        val DiffCallback = object : DiffUtil.ItemCallback<SelectableMedia>() {
             override fun areItemsTheSame(
-                oldItem: SelectableImage,
-                newItem: SelectableImage
+                oldItem: SelectableMedia,
+                newItem: SelectableMedia
             ): Boolean = oldItem.id == newItem.id
 
             override fun areContentsTheSame(
-                oldItem: SelectableImage,
-                newItem: SelectableImage
+                oldItem: SelectableMedia,
+                newItem: SelectableMedia
             ): Boolean = oldItem == newItem
 
             override fun getChangePayload(
-                oldItem: SelectableImage,
-                newItem: SelectableImage
+                oldItem: SelectableMedia,
+                newItem: SelectableMedia
             ): Any? = when {
                 oldItem.selected != newItem.selected -> SELECTED_PAYLOAD
                 else -> null

--- a/photopicker/src/main/java/lv/chi/photopicker/adapter/SelectableMedia.kt
+++ b/photopicker/src/main/java/lv/chi/photopicker/adapter/SelectableMedia.kt
@@ -2,7 +2,8 @@ package lv.chi.photopicker.adapter
 
 import android.net.Uri
 
-internal data class SelectableImage(
+
+internal data class SelectableMedia(
     val id: Int,
     val uri: Uri,
     val selected: Boolean

--- a/photopicker/src/main/java/lv/chi/photopicker/loader/ImageLoader.kt
+++ b/photopicker/src/main/java/lv/chi/photopicker/loader/ImageLoader.kt
@@ -5,6 +5,5 @@ import android.net.Uri
 import android.widget.ImageView
 
 interface ImageLoader {
-
     fun loadImage(context: Context, view: ImageView, uri: Uri)
 }

--- a/photopicker/src/main/res/layout/fragment_media_picker.xml
+++ b/photopicker/src/main/res/layout/fragment_media_picker.xml
@@ -89,7 +89,7 @@
                 app:layout_constraintTop_toBottomOf="@+id/barrier" />
 
             <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/photos"
+                android:id="@+id/mediaItems"
                 android:layout_width="0dp"
                 android:layout_height="0dp"
                 android:clipToPadding="false"
@@ -101,7 +101,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/barrier"
                 app:spanCount="3"
-                tools:listitem="@layout/view_pickable_image" />
+                tools:listitem="@layout/view_pickable_media_item" />
 
             <include
                 layout="@layout/view_grant_permission"

--- a/photopicker/src/main/res/layout/view_pickable_media_item.xml
+++ b/photopicker/src/main/res/layout/view_pickable_media_item.xml
@@ -5,7 +5,7 @@
     android:layout_height="wrap_content">
 
     <ImageView
-        android:id="@+id/photo_item"
+        android:id="@+id/media_item"
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:foreground="@drawable/bg_ripple_image"
@@ -14,7 +14,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent"
-        tools:ignore="UnusedAttribute" />
+        tools:ignore="ContentDescription,UnusedAttribute" />
 
     <CheckBox
         android:id="@+id/checkbox"

--- a/photopicker/src/main/res/values/strings.xml
+++ b/photopicker/src/main/res/values/strings.xml
@@ -10,11 +10,11 @@
     <string name="picker_select_video">Select Video</string>
     <string name="picker_no_camera">No camera app is installed</string>
     <plurals name="picker_selected_count">
-        <item quantity="one">%d photo selected</item>
-        <item quantity="other">%d photos selected</item>
+        <item quantity="one">%d items selected</item>
+        <item quantity="other">%d items selected</item>
     </plurals>
     <plurals name="picker_max_selection_reached">
-        <item quantity="one">You can pick only %d image</item>
-        <item quantity="other">You can pick only %d images</item>
+        <item quantity="one">You can pick only %d items</item>
+        <item quantity="other">You can pick only %d items</item>
     </plurals>
 </resources>

--- a/photopicker/src/main/res/values/strings.xml
+++ b/photopicker/src/main/res/values/strings.xml
@@ -7,6 +7,7 @@
     <string name="picker_empty_media">Your media library is empty</string>
     <string name="picker_allow">Allow</string>
     <string name="picker_select_photo">Select photo</string>
+    <string name="picker_select_video">Select Video</string>
     <string name="picker_no_camera">No camera app is installed</string>
     <plurals name="picker_selected_count">
         <item quantity="one">%d photo selected</item>

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -25,11 +25,11 @@ dependencies {
 
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation "androidx.core:core-ktx:1.2.0-beta01"
+    implementation 'androidx.core:core-ktx:1.3.0-alpha02'
     implementation "androidx.appcompat:appcompat:1.1.0"
     implementation "androidx.constraintlayout:constraintlayout:1.1.3"
-    implementation "com.google.android.material:material:1.1.0-beta01"
+    implementation 'com.google.android.material:material:1.2.0-alpha05'
 
-    implementation "com.github.bumptech.glide:glide:3.7.0"
-    implementation "com.squareup.picasso:picasso:2.5.2"
+    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    implementation 'com.squareup.picasso:picasso:2.71828'
 }

--- a/sample/src/main/java/lv/chi/chiliphotopicker/loaders/GlideImageLoader.kt
+++ b/sample/src/main/java/lv/chi/chiliphotopicker/loaders/GlideImageLoader.kt
@@ -11,8 +11,8 @@ class GlideImageLoader: ImageLoader {
 
     override fun loadImage(context: Context, view: ImageView, uri: Uri) {
         Glide.with(context)
-            .load(uri)
             .asBitmap()
+            .load(uri)
             .placeholder(R.drawable.bg_placeholder)
             .centerCrop()
             .into(view)

--- a/sample/src/main/java/lv/chi/chiliphotopicker/loaders/PicassoImageLoader.kt
+++ b/sample/src/main/java/lv/chi/chiliphotopicker/loaders/PicassoImageLoader.kt
@@ -10,7 +10,7 @@ import lv.chi.photopicker.loader.ImageLoader
 class PicassoImageLoader: ImageLoader {
 
     override fun loadImage(context: Context, view: ImageView, uri: Uri) {
-        Picasso.with(context)
+        Picasso.get()
             .load(uri)
             .placeholder(R.drawable.bg_placeholder)
             .fit()


### PR DESCRIPTION
I've been using this very useful library a lot so I decided to add the support for choosing and taking videos. I have also upgraded all dependencies to latest versions and made appropriate syntax corrections where necessary. 

This can be activated by passing an optional parameter `pickerType` to the `newInstance` method.
By default only photos can be selected. 

    MediaPickerFragment.newInstance(
            multiple = true,
            allowCamera = true,
            pickerType = MediaPickerFragment.PickerType.VIDEO, //required for video mode
            maxSelection = 5,
            theme = R.style.ChiliPhotoPicker_Dark
        ).show(supportFragmentManager, "picker")
Almost every core class has been renamed (apparently we can't keep the photo prefixes because there is video suppport now)  so this enhancement causes a breaking change.
These are the classes that have changed.

|Old name  |  New Name|
|--|--|
| `SelectablePhoto` |`SelectableMedia`  |
|`PhotoPickerFragment`|`MediaPickerFragment`|
|`PhotoPickerAdapter`|`MediaPickerAdapter`|

Consumers of this class only need to worry about renaming `PhotoPickerFragment` to `MediaPickerFragment`
and the callback from `PhotoPickerFragment.Callback` to `MediaPickerFragment.Callback`

Everything else remains the same. 

